### PR TITLE
Add GUI element and corresponding code for adjusting iteration speed

### DIFF
--- a/sort_visualizer/gui.py
+++ b/sort_visualizer/gui.py
@@ -19,9 +19,16 @@ class GUI:
         self.layout = [
             [sg.Button('Start')],
 
-            [sg.Slider(range=(10, 200), orientation='horizontal', key='slider',
+            [sg.Text('Number of elements:', key='label_num_elements'),
+            sg.Slider(range=(10, 200), orientation='horizontal', key='slider',
                        change_submits=True, disable_number_display=True),
-             sg.Text('Array access: 0    ', key='text')],
+            sg.Text('Iteration speed:', key='label_iter_spd'),
+            sg.Slider(range=(0.1, 2), orientation='horizontal', 
+                       key='iteration_speed', change_submits=True, 
+                       disable_number_display=True, default_value=1,
+                       resolution=0.01)],
+            
+            [sg.Text('Array access: 0    ', key='text')],
 
             [self.graph],
         ]
@@ -54,8 +61,11 @@ class GUI:
             if event == 'Start' or self.slider_value != int(values['slider']):
                 self.started = True
                 self.slider_value = int(values['slider'])
+                iteration_speed = float(values['iteration_speed'])
                 self.sorter._reset_array_access()
-                self.sorter._calculate_and_set_timeout(self.slider_value)
+                self.sorter._calculate_and_set_timeout(
+                    self.slider_value, iteration_speed
+                )
                 self._draw_screen()
 
             if self.started:

--- a/sort_visualizer/sorter.py
+++ b/sort_visualizer/sorter.py
@@ -75,8 +75,8 @@ class Sorter:
         self.window.FindElement('text').Update(
             f'Array access: {self.array_access}')
 
-    def _calculate_and_set_timeout(self, value: int):
-        self.timeout = value * 3 - 25
+    def _calculate_and_set_timeout(self, value: int, speed_modifier: float):
+        self.timeout = (value * 3 - 25) * speed_modifier
 
     def _calculate_and_set_bar_width(self, value: int):
         self.bar_width = int(self.graph.Size[0] / (value * 2))


### PR DESCRIPTION
I haven't used PySimpleGUI before so this seemed like a cool project to have a look at. If you don't think the new feature fits, then just close this PR.

This adds an additional slider element that can be used to adjust iteration speed (ranging between 10% and 200% of default/pre-PR iteration speed). It also slightly rearranges the layout of the controls and adds a label for the 'number of elements' slider, to clarify which slider is used for what.
<img width="871" alt="sort" src="https://user-images.githubusercontent.com/65363390/127745650-22bc33e3-89de-4ea6-9513-2943e198556b.png">